### PR TITLE
Fix classname bug on KDE Plasma 6

### DIFF
--- a/tr.com.ikooskar.ikoOSKAR.json
+++ b/tr.com.ikooskar.ikoOSKAR.json
@@ -26,7 +26,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/ikolomiko/ikooskar-qt",
-                    "commit": "7445d185069e9d496a0539ed90b547f922f02a5c"
+                    "commit": "294507f6cd26cd14068368abf3fdb0f4148e7798"
                 }
             ]
         }


### PR DESCRIPTION
For some reason unbeknownst to any sane humanbeing, KDE developers thought it would be a great idea to enable keyboard shortcuts (aka mnemonics) for all Qt applications on KDE Plasma 6, regardless of the app developers' decision. These shortcut providers insert random ampersand symbols to TabWidget header texts, essentially breaking the code which figures out which class is currently selected on DatabasePage. This little patch removes the ampersand symbol manually when the tabText() method is accessed.